### PR TITLE
Add RSS feed auto-discovery

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/feed.xml"
+  [headers.values]
+    Content-Type: "application/rss+xml"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[headers]]
   for = "/feed.xml"
   [headers.values]
-    Content-Type: "application/rss+xml"
+    Content-Type = "application/rss+xml"

--- a/src/layouts/root.webc
+++ b/src/layouts/root.webc
@@ -21,6 +21,8 @@
   <link rel="stylesheet" href="/style.css" webc:raw>
   <style @html="this.getCSS(this.page.url)"></style>
   <script @html="this.getJS(this.page.url)"></script>
+
+	<link rel="alternate" href="/feed.xml" type="application/rss+xml">
 </head>
 
 <body @html="this.content"></body>


### PR DESCRIPTION
Hello!

First off, thanks for creating this really helful and easy-to-digest resource. The tutorials published so far have gone a long way to help me wrap my head around WebC.

## Description

This PR adds a `<link>` element to the site's `<head>` with the necessary attributes to enable autodiscovery of the RSS feed via browser extensions, feed readers, etc. Also, a small addition to the `netlify.toml` config should get Netlify to serve the RSS feed's XML file with the right MIME type.

Thanks for considering this change and I look forward to more of your tutorials!