### PR TITLE
Fix typo (nokeep -> keep)

### DIFF
--- a/src/pages/recipes/remove-custom-elements-from-your-output.md
+++ b/src/pages/recipes/remove-custom-elements-from-your-output.md
@@ -110,7 +110,7 @@ Add both of these attributes to the root `<div>`.
 <figure>
 
 ```html
-<div class="hero" webc:root webc:nokeep>
+<div class="hero" webc:root webc:keep>
   <slot name="image"></slot>
   <h1><slot name="title"></slot></h1>
 </div>


### PR DESCRIPTION
In the second example, `webc:root` was used in conjunction with `webc:nokeep`. Based on the rest of the article, and based on local testing, I believe that's a typo. It's supposed to be `webc:root` combined with `webc:keep` 🙂