### PR TITLE
Rename luxon-time to time

### DIFF
--- a/src/_includes/components/card-carousel.webc
+++ b/src/_includes/components/card-carousel.webc
@@ -14,7 +14,7 @@
 			<p @raw="item.data.description"></p>
 			<footer>
 				<strong>Updated:</strong>
-				<luxon-time :@value="item.date" @machine-format="yyyy-LL-dd"></luxon-time>
+				<time :@value="item.date" @machine-format="yyyy-LL-dd"></time>
 			</footer>
 		</div>
 	</article>

--- a/src/_includes/components/time.webc
+++ b/src/_includes/components/time.webc
@@ -7,5 +7,5 @@
 	const datetime = machineFormat ? dt.toFormat(machineFormat) : dt.toISO();
 	const display = dt.toFormat(format || site.dateFormat);
 
-	`<time datetime="${datetime}">${display}</time>`
+	`<time webc:raw datetime="${datetime}">${display}</time>`
 </script>

--- a/src/_includes/layouts/plain.webc
+++ b/src/_includes/layouts/plain.webc
@@ -6,7 +6,7 @@ layout: layouts/default.webc
 	<bread-crumbs></bread-crumbs>
 	<header>
 		<h1 @html="title"></h1>
-		<p>Updated: <luxon-time :@value="page.date" @machine-format="yyyy-LL-dd"></luxon-time></p>
+		<p>Updated: <time :@value="page.date" @machine-format="yyyy-LL-dd"></time></p>
 	</header>
 	<div id="skip" @html="content" tabindex="-1"></div>
 </article>


### PR DESCRIPTION
After discovering an errant @html in one of my layouts and converting to @raw, overriding the time element works everywhere. It wasn’t failing because anything was wrong with it, it was being reprocessed as a WebC component in the layout chain.