### PR TITLE
Avoid PostCSS warning

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -13,7 +13,8 @@ module.exports = function(eleventyConfig) {
 	eleventyConfig.addExtension("css", {
 		outputFileExtension: "css",
 		compile: async function(inputContent) {
-			const result = await postcss([atImport]).process(inputContent);
+			// from: undefined is required to avoid a warning - see: https://stackoverflow.com/a/63193341/650482
+			const result = await postcss([atImport]).process(inputContent, { from: undefined });
 
 			return async () => result.css;
 		},


### PR DESCRIPTION
PostCSS warns about the missing from option which could result in wrong source map. Explicitly add the from option to avoid the warning.